### PR TITLE
Save progress, and load previously saved game by default

### DIFF
--- a/components/SudokuGrid.js
+++ b/components/SudokuGrid.js
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { Alert, View, Text, TextInput, Pressable, StyleSheet, Keyboard, TouchableWithoutFeedback } from 'react-native';
 import AntDesign from '@expo/vector-icons/AntDesign';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const initialPuzzle = [
   [5, 3, null, null, 7, null, null, null, null],
@@ -26,24 +27,46 @@ const completedPuzzle = [
 ];
 
 
-const initialPuzzleCopy = JSON.parse(JSON.stringify(initialPuzzle));
+const SUDOKU_PUZZLE_KEY = 'sudokuPuzzle';
+
 
 
 const SudokuGrid = () => {
-  const [grid, setGrid] = useState(JSON.parse(JSON.stringify(initialPuzzle)));
+  const [grid, setGrid] = useState(initialPuzzle);
   const [focusedCell, setFocusedCell] = useState({ row: null, col: null });
   const [selectedValue, setSelectedValue] = useState(null);
   const [correctnessGrid, setCorrectnessGrid] = useState(
     Array(9).fill(null).map(() => Array(9).fill(null))
   );
-  const [notStopped, setNotStopped] = useState(true)
+  const [notStopped, setNotStopped] = useState(true);
+
+  useEffect(() => {
+    const loadPuzzle = async () => {
+      try {
+        const savedPuzzle = await AsyncStorage.getItem(SUDOKU_PUZZLE_KEY);
+        console.log("Loading puzzle. savedPuzzle is " + savedPuzzle)
+        const initialPuzzleCopy = savedPuzzle ? JSON.parse(savedPuzzle) :  JSON.parse(JSON.stringify(initialPuzzle));
+        setGrid(initialPuzzleCopy);
+      } catch (e) {
+        console.error('Failed to load puzzle:', e);
+      };
+
+      }
+    loadPuzzle();
+  }, []);
 
 
-  const handleChange = (text, row, col) => {
+  const handleChange = async (text, row, col) => {
     const newGrid = [...grid];
     const value = parseInt(text);
     newGrid[row][col] = isNaN(value) ? null : value;
     setGrid(newGrid);
+
+    try {
+      await AsyncStorage.setItem(SUDOKU_PUZZLE_KEY, JSON.stringify(newGrid));
+    } catch (e) {
+      console.error('Failed to save puzzle:', e);
+    }
   };
 
   const handleCellPress = (row, col) => {
@@ -79,12 +102,19 @@ const SudokuGrid = () => {
     
   };
 
-  const resetGame = () => {
-    setGrid(JSON.parse(JSON.stringify(initialPuzzle)));
+  const resetGame = async () => {
+    const initialPuzzleReset = JSON.parse(JSON.stringify(initialPuzzle));
+    setGrid(initialPuzzleReset);
     setFocusedCell({ row: null, col: null });
     setSelectedValue(null);
     setCorrectnessGrid(Array(9).fill(null).map(() => Array(9).fill(null)));
     setNotStopped(true);
+
+    try {
+      await AsyncStorage.setItem(SUDOKU_PUZZLE_KEY, JSON.stringify(initialPuzzleReset));
+    } catch (e) {
+      console.error('Failed to save puzzle:', e);
+    }
   };  
   
   const handleFinishedPress = () => {
@@ -161,7 +191,7 @@ const SudokuGrid = () => {
           {grid.map((row, rowIndex) => (
             <View key={rowIndex} style={styles.row}>
               {row.map((cell, colIndex) => {
-                const isEditable = initialPuzzleCopy[rowIndex][colIndex] === null;
+                const isEditable = initialPuzzle[rowIndex][colIndex] === null;
   
                 if (isEditable && notStopped) {
                   return (


### PR DESCRIPTION
Every time a change in the state of the puzzle is registered, the new state is saved. When the app loads up again, we check to see if a previously saved instance of the game exists. If it does, we use that, otherwise, we load a new puzzle.

Once levels are introduced, we would want to store that as a variable as well.